### PR TITLE
feat(price): add price percentile calculation and storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,43 +3,47 @@
 
 # Pull quotes for specified symbols
 pull-quotes:
-	RUST_LOG=debug cargo run -- pull-quotes /home/tianhai82/hobby/market_int/data/symbols.csv
+	RUST_LOG=debug cargo run -- pull-quotes /Volumes/Ext/code/personal/market_int/data/symbols.csv
 
 # Calculate Average True Range (ATR)
 calculate-atr:
-	RUST_LOG=debug cargo run -- calculate-atr /home/tianhai82/hobby/market_int/data/symbols.csv
+	RUST_LOG=debug cargo run -- calculate-atr /Volumes/Ext/code/personal/market_int/data/symbols.csv
 
 # Calculate Maximum Drop for 5-day period
 calculate-maxdrop-5:
-	RUST_LOG=debug cargo run -- calculate-max-drop /home/tianhai82/hobby/market_int/data/symbols.csv 5
+	RUST_LOG=debug cargo run -- calculate-max-drop /Volumes/Ext/code/personal/market_int/data/symbols.csv 5
 
 # Calculate Maximum Drop for 20-day period
 calculate-maxdrop-20:
-	RUST_LOG=debug cargo run -- calculate-max-drop /home/tianhai82/hobby/market_int/data/symbols.csv 20
+	RUST_LOG=debug cargo run -- calculate-max-drop /Volumes/Ext/code/personal/market_int/data/symbols.csv 20
 
 # Calculate Sharpe Ratio
 calculate-sharpe:
-	RUST_LOG=debug cargo run -- calculate-sharpe-ratio /home/tianhai82/hobby/market_int/data/symbols.csv
+	RUST_LOG=debug cargo run -- calculate-sharpe-ratio /Volumes/Ext/code/personal/market_int/data/symbols.csv
+
+# Calculate Price Percentile
+calculate-price-percentile:
+	RUST_LOG=debug cargo run -- calculate-price-percentile /Volumes/Ext/code/personal/market_int/data/symbols.csv
 
 # Pull option chain data with 5-day expiry
 pull-option-chain-5day:
-	RUST_LOG=debug cargo run -- pull-option-chain5-day /home/tianhai82/hobby/market_int/data/symbols.csv
+	RUST_LOG=debug cargo run -- pull-option-chain5-day /Volumes/Ext/code/personal/market_int/data/symbols.csv
 
 # Pull option chain data with 20-day expiry
 pull-option-chain-20day:
-	RUST_LOG=debug cargo run -- pull-option-chain20-day /home/tianhai82/hobby/market_int/data/symbols.csv
+	RUST_LOG=debug cargo run -- pull-option-chain20-day /Volumes/Ext/code/personal/market_int/data/symbols.csv
 
 # Legacy target - maps to 5-day option chain
 pull-option-chain:
-	RUST_LOG=debug cargo run -- pull-option-chain5-day /home/tianhai82/hobby/market_int/data/symbols.csv
+	RUST_LOG=debug cargo run -- pull-option-chain5-day /Volumes/Ext/code/personal/market_int/data/symbols.csv
 
 # Publish option chain to telegram
 publish-option-chain:
-	RUST_LOG=debug cargo run -- publish-option-chain /home/tianhai82/hobby/market_int/data/symbols.csv
+	RUST_LOG=debug cargo run -- publish-option-chain /Volumes/Ext/code/personal/market_int/data/symbols.csv
 
 # Perform all operations (quotes, ATR, Sharpe, option chains)
 perform-all:
-	RUST_LOG=debug cargo run -- perform-all /home/tianhai82/hobby/market_int/data/symbols.csv
+	RUST_LOG=debug cargo run -- perform-all /Volumes/Ext/code/personal/market_int/data/symbols.csv
 
 # Test Tiger API with comma-separated symbols (e.g., make test-tiger SYMBOLS="AAPL,MSFT,GOOGL")
 test-tiger:
@@ -81,7 +85,8 @@ help:
 	@echo "  calculate-atr        - Calculate ATR"
 	@echo "  calculate-maxdrop-5  - Calculate 5-day max drop"
 	@echo "  calculate-maxdrop-20 - Calculate 20-day max drop"
-	@echo "  calculate-sharpe     - Calculate Sharpe ratio"
+	@echo "  calculate-sharpe       - Calculate Sharpe ratio"
+	@echo "  calculate-price-percentile - Calculate price percentile"
 	@echo "  pull-option-chain-5day  - Pull 5-day option chains"
 	@echo "  pull-option-chain-20day - Pull 20-day option chains"
 	@echo "  pull-option-chain    - Legacy: same as pull-option-chain-5day"

--- a/job.yaml
+++ b/job.yaml
@@ -21,7 +21,7 @@ spec:
                   bucketName: opt-intel
           containers:
             - name: market-int-1
-              image: us-west1-docker.pkg.dev/opt-intel/docker-repo/market-int:0.5.1
+              image: us-west1-docker.pkg.dev/opt-intel/docker-repo/market-int:0.5.2
               command:
                 - /market_int/market_int
               args:

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,3 +3,4 @@ pub const MIN_OPEN_INTEREST: u32 = 50;
 pub const PERCENTILE: f64 = 0.9;
 pub const SHARPE_MIN_CANDLES: usize = 14;
 pub const DEFAULT_RISK_FREE_RATE: f64 = 0.0; // use 0
+pub const PRICE_PERCENTILE_DAYS: u32 = 20;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ mod maxdrop;
 mod option;
 // Sharpe ratio calculation and storage.
 mod sharpe;
+// Price percentile calculation and storage.
+mod price_percentile;
 /// module to read symbols from symbol file
 mod symbols;
 // Tiger API client
@@ -36,6 +38,8 @@ mod store {
     pub mod max_drop;
     /// option range storage.
     pub mod option_chain;
+    /// price percentile storage.
+    pub mod price_percentile;
     /// Sharpe ratio storage.
     pub mod sharpe_ratio;
     /// SQLite database interaction.
@@ -140,6 +144,9 @@ enum Commands {
         period: String, // "5" or "20"
     },
     CalculateSharpeRatio {
+        symbols_file_path: String,
+    },
+    CalculatePricePercentile {
         symbols_file_path: String,
     },
     // Test Tiger API
@@ -259,6 +266,13 @@ async fn main() {
             }
         }
 
+        Commands::CalculatePricePercentile { symbols_file_path } => {
+            match price_percentile::calculate_and_save(&symbols_file_path, &mut conn) {
+                Ok(_) => log::info!("Successfully calculated and saved price percentiles"),
+                Err(err) => log::error!("Error calculating price percentiles: {}", err),
+            }
+        }
+
         Commands::PerformAll { symbols_file_path } => {
             match quotes::pull_and_save(&symbols_file_path, &mut conn).await {
                 Ok(_) => log::info!("Successfully pulled and saved quotes"),
@@ -281,6 +295,10 @@ async fn main() {
             ) {
                 Ok(_) => log::info!("Successfully calculated and saved Sharpe ratios"),
                 Err(err) => log::error!("Error calculating Sharpe ratios: {}", err),
+            }
+            match price_percentile::calculate_and_save(&symbols_file_path, &mut conn) {
+                Ok(_) => log::info!("Successfully calculated and saved price percentiles"),
+                Err(err) => log::error!("Error calculating price percentiles: {}", err),
             }
             // Initialize Tiger API requester once to cache option expiration data
             let mut requester = match tiger::api_caller::Requester::new().await {

--- a/src/model.rs
+++ b/src/model.rs
@@ -8,8 +8,8 @@ use std::{
 
 use csv::Writer;
 use rusqlite::{
-    ToSql,
     types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef},
+    ToSql,
 };
 use serde::{Deserialize, Serialize};
 use telegram_bot_api::bot::APIResponseError;
@@ -50,6 +50,13 @@ pub struct MaxDropPeriod {
     pub period: usize,
     pub percentile_drop: f64,
     pub ema_drop: f64,
+    pub timestamp: u32,
+}
+
+#[derive(Debug)]
+pub struct PricePercentile {
+    pub symbol: String,
+    pub percentile: f64,
     pub timestamp: u32,
 }
 
@@ -130,6 +137,7 @@ pub struct OptionStrikeCandle {
 pub fn option_chain_to_csv_vec(
     all_chains: &[OptionStrikeCandle],
     sharpe_ratios: &HashMap<String, f64>,
+    price_percentiles: &HashMap<String, f64>,
 ) -> Result<Vec<u8>> {
     let buf = BufWriter::new(Vec::new());
     let mut writer = Writer::from_writer(buf);
@@ -156,12 +164,17 @@ pub fn option_chain_to_csv_vec(
             "strike_from",
             "strike_to",
             "sharpe_ratio",
+            "price_percentile",
         ])
         .map_err(QuotesError::CsvError)?;
 
     // Write the data rows.
     for chain in all_chains {
         let sharpe_ratio = sharpe_ratios.get(&chain.underlying).copied().unwrap_or(0.0);
+        let price_percentile = price_percentiles
+            .get(&chain.underlying)
+            .copied()
+            .unwrap_or(0.0);
 
         writer
             .write_record([
@@ -184,6 +197,7 @@ pub fn option_chain_to_csv_vec(
                 &chain.strike_from.to_string(),
                 &chain.strike_to.to_string(),
                 &format!("{:.3}", sharpe_ratio),
+                &format!("{:.3}", price_percentile),
             ])
             .map_err(QuotesError::CsvError)?;
     }

--- a/src/option.rs
+++ b/src/option.rs
@@ -13,7 +13,7 @@ use telegram_bot_api::{
 use crate::{
     constants,
     model::{self, QuotesError},
-    store::{candle, max_drop, option_chain, sharpe_ratio},
+    store::{candle, max_drop, option_chain, price_percentile, sharpe_ratio},
     symbols,
     tiger::api_caller::Requester,
 };
@@ -277,7 +277,23 @@ pub async fn retrieve_option_chains_with_expiry(
         }
     }
 
-    publish_to_telegram(&all_chains, &sharpe_ratios, period).await
+    // Collect price percentiles for all symbols
+    let mut price_percentiles: HashMap<String, f64> = HashMap::new();
+    for symbol in &symbols {
+        match price_percentile::get_price_percentile(conn, symbol) {
+            Ok(Some(percentile)) => {
+                price_percentiles.insert(symbol.clone(), percentile);
+            }
+            Ok(None) => {
+                log::warn!("No price percentile found for symbol: {}", symbol);
+            }
+            Err(err) => {
+                log::error!("Failed to get price percentile for {}: {}", symbol, err);
+            }
+        }
+    }
+
+    publish_to_telegram(&all_chains, &sharpe_ratios, &price_percentiles, period).await
 }
 
 /// Calculates the expiration date based on the specified timeframe.
@@ -325,6 +341,7 @@ pub async fn publish_option_chains(
 
     let mut all_chains: Vec<model::OptionStrikeCandle> = Vec::with_capacity(100);
     let mut sharpe_ratios: HashMap<String, f64> = HashMap::new();
+    let mut price_percentiles: HashMap<String, f64> = HashMap::new();
 
     for symbol in &symbols {
         let chains = option_chain::retrieve_option_chain(&mut conn, symbol);
@@ -348,19 +365,33 @@ pub async fn publish_option_chains(
                 log::error!("Failed to get Sharpe ratio for {}: {}", symbol, err);
             }
         }
+
+        // Get price percentile for this symbol
+        match price_percentile::get_price_percentile(&conn, symbol) {
+            Ok(Some(percentile)) => {
+                price_percentiles.insert(symbol.clone(), percentile);
+            }
+            Ok(None) => {
+                log::warn!("No price percentile found for symbol: {}", symbol);
+            }
+            Err(err) => {
+                log::error!("Failed to get price percentile for {}: {}", symbol, err);
+            }
+        }
     }
 
-    publish_to_telegram(&all_chains, &sharpe_ratios, period).await
+    publish_to_telegram(&all_chains, &sharpe_ratios, &price_percentiles, period).await
 }
 
 /// Publishes option chain data to Telegram
 pub async fn publish_to_telegram(
     all_chains: &[model::OptionStrikeCandle],
     sharpe_ratios: &HashMap<String, f64>,
+    price_percentiles: &HashMap<String, f64>,
     period: usize,
 ) -> model::Result<()> {
     // Save all_chains to a csv file and upload it to dropbox
-    let csv = model::option_chain_to_csv_vec(all_chains, sharpe_ratios)?;
+    let csv = model::option_chain_to_csv_vec(all_chains, sharpe_ratios, price_percentiles)?;
 
     let now_singapore = Local::now().with_timezone(&Singapore);
     let formatted_date = now_singapore.format("%d%b_%H%M").to_string();

--- a/src/price_percentile.rs
+++ b/src/price_percentile.rs
@@ -1,0 +1,65 @@
+use crate::{
+    constants, model,
+    store::{self, candle},
+    symbols,
+};
+use rusqlite::Connection;
+
+pub fn calculate_and_save(symbols_file_path: &str, conn: &mut Connection) -> model::Result<()> {
+    let symbols = symbols::read_symbols_from_file(symbols_file_path)?;
+
+    store::price_percentile::create_table(conn)?;
+
+    let mut percentiles: Vec<model::PricePercentile> = Vec::with_capacity(symbols.len());
+
+    for symbol in symbols {
+        let candles =
+            match candle::get_candles(conn, symbol.as_str(), constants::PRICE_PERCENTILE_DAYS) {
+                Ok(candles) => candles,
+                Err(_) => {
+                    log::warn!("No candles found for {}, skipping", symbol);
+                    continue;
+                }
+            };
+
+        if candles.is_empty() {
+            log::warn!("No candles found for {}, skipping", symbol);
+            continue;
+        }
+
+        let timestamp = candles.last().unwrap().timestamp;
+        let percentile = calculate_price_percentile(&candles);
+
+        percentiles.push(model::PricePercentile {
+            symbol: symbol.clone(),
+            percentile,
+            timestamp,
+        });
+
+        log::info!(
+            "Calculated price percentile for {}: {:.4}",
+            symbol,
+            percentile
+        );
+    }
+
+    store::price_percentile::save_price_percentiles(conn, &percentiles)?;
+    Ok(())
+}
+
+fn calculate_price_percentile(candles: &[model::Candle]) -> f64 {
+    let close_prices: Vec<f64> = candles.iter().map(|c| c.close).collect();
+
+    let min_price = close_prices.iter().copied().fold(f64::INFINITY, f64::min);
+    let max_price = close_prices
+        .iter()
+        .copied()
+        .fold(f64::NEG_INFINITY, f64::max);
+
+    if max_price == min_price {
+        return 0.5;
+    }
+
+    let current_close = close_prices.last().copied().unwrap();
+    (current_close - min_price) / (max_price - min_price)
+}

--- a/src/store/price_percentile.rs
+++ b/src/store/price_percentile.rs
@@ -1,0 +1,64 @@
+use super::super::model;
+use rusqlite::{params, Connection, Result};
+
+pub fn create_table(conn: &Connection) -> Result<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS price_percentile (
+            symbol TEXT NOT NULL,
+            percentile REAL NOT NULL,
+            timestamp INTEGER NOT NULL
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_price_percentile_symbol ON price_percentile (symbol);",
+        [],
+    )?;
+    Ok(())
+}
+
+pub fn save_price_percentile(
+    conn: &Connection,
+    symbol: &str,
+    percentile: f64,
+    timestamp: u32,
+) -> model::Result<()> {
+    create_table(conn)?;
+    let mut stmt = conn.prepare(
+        "REPLACE INTO price_percentile (symbol, percentile, timestamp) VALUES (?1, ?2, ?3)",
+    )?;
+    stmt.execute(params![symbol, percentile, timestamp])?;
+    Ok(())
+}
+
+pub fn save_price_percentiles(
+    conn: &mut Connection,
+    percentiles: &[model::PricePercentile],
+) -> model::Result<()> {
+    let transaction = conn.transaction()?;
+    {
+        let mut stmt = transaction.prepare(
+            "REPLACE INTO price_percentile (symbol, percentile, timestamp) VALUES (?1, ?2, ?3)",
+        )?;
+        for pp in percentiles {
+            stmt.execute(params![pp.symbol, pp.percentile, pp.timestamp])?;
+        }
+    }
+    transaction.commit()?;
+    Ok(())
+}
+
+pub fn get_price_percentile(conn: &Connection, symbol: &str) -> model::Result<Option<f64>> {
+    let mut stmt = conn.prepare(
+        "SELECT percentile FROM price_percentile WHERE symbol = ?1 ORDER BY timestamp DESC LIMIT 1",
+    )?;
+    let mut rows = stmt.query(params![symbol])?;
+
+    match rows.next()? {
+        Some(row) => {
+            let percentile: f64 = row.get(0)?;
+            Ok(Some(percentile))
+        }
+        None => Ok(None),
+    }
+}


### PR DESCRIPTION
Add new price percentile feature that calculates the relative position of current close price within the high-low range over a configurable period (default 20 days).

- Add price_percentile module with calculation logic
- Add store module for persisting percentiles to SQLite
- Integrate price percentile into option chain CSV exports
- Add CLI command and Makefile target for percentile calculation
- Include price percentile in perform-all workflow